### PR TITLE
Fixed Prototype Pollution on node-obj-resolve

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,11 @@ module.exports = function resolve (obj, path, value) {
   if (typeof obj !== 'object' || obj === null) {
     return undefined
   }
+  
+  if(path.includes('__proto__') || path.includes('constructor') || path.includes('prototype')){
+    return undefined;
+  }
+  
   if ('string' == typeof path) {
     path = path.replace(/\[(\w+)\]/g, '.$1'); // convert indexes to properties
     path = path.replace(/^\./, '');           // strip a leading dot


### PR DESCRIPTION
### 📊 Metadata *

Prototype Pollution bug

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-obj-resolve/

### ⚙️ Description *

`obj-resolve` is vulnerable to Prototype Pollution. This package allowing for modification of prototype behavior, which may result in Information Disclosure/DoS/RCE.

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.

### 💻 Technical Description *

The bug is fixed by validating the input `path` to check for prototypes. It is implemented by a simple validation to check for prototype keywords `(__proto__, constructor and prototype)`, where if it exists, the function returns the object without modifying it, thus fixing the Prototype Pollution Vulnerability. 

### 🐛 Proof of Concept (PoC) *

Clone the project, install the required dependencies and on running the below snippet of code, it triggers prototype pollution and logs `Yes! Its Polluted`.
```javascript
// poc.js
var objResolve = require("obj-resolve")
var obj = {}
console.log("Before : " + {}.polluted);
objResolve(obj,"__proto__.polluted","Yes! Its Polluted");
console.log("After : " + {}.polluted);
```

![image](https://user-images.githubusercontent.com/16708391/107801596-483dff80-6d86-11eb-95e7-e560c35d0d2c.png)


### 🔥 Proof of Fix (PoF) *

After the fix is applied, it returns `undefined` since the polluted referred in the PoC is no more accessible(which is intended). Hence fixing the issue.

![image](https://user-images.githubusercontent.com/16708391/107801667-6146b080-6d86-11eb-946a-988f1084e5ae.png)


### 👍 User Acceptance Testing (UAT)

Just prevented some keywords as `path` and no breaking changes are introduced. :)
